### PR TITLE
rename Command name and event name since that is difficult to understand

### DIFF
--- a/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankAccountCreateCommand.java
+++ b/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankAccountCreateCommand.java
@@ -19,10 +19,13 @@ package org.axonframework.samples.bank.api.bankaccount;
 import lombok.Value;
 import org.axonframework.commandhandling.TargetAggregateIdentifier;
 
+import javax.validation.constraints.Min;
+
 @Value
-public class WithdrawMoneyCommand {
+public class BankAccountCreateCommand {
 
     @TargetAggregateIdentifier
     private String bankAccountId;
-    private long amountOfMoney;
+    @Min(value = 0, message = "Overdraft limit must not be less than zero")
+    private long overdraftLimit;
 }

--- a/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankAccountMoneyAddedEvent.java
+++ b/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankAccountMoneyAddedEvent.java
@@ -16,9 +16,13 @@
 
 package org.axonframework.samples.bank.api.bankaccount;
 
-public class MoneyOfFailedBankTransferReturnedEvent extends MoneyAddedEvent {
+import lombok.Value;
+import lombok.experimental.NonFinal;
 
-    public MoneyOfFailedBankTransferReturnedEvent(String bankAccountId, long amountOfMoneyDeposited) {
-        super(bankAccountId, amountOfMoneyDeposited);
-    }
+@Value
+@NonFinal
+public abstract class BankAccountMoneyAddedEvent {
+
+    private String bankAccountId;
+    private long amount;
 }

--- a/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankAccountMoneyDepositCommand.java
+++ b/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankAccountMoneyDepositCommand.java
@@ -20,7 +20,7 @@ import lombok.Value;
 import org.axonframework.commandhandling.TargetAggregateIdentifier;
 
 @Value
-public class DepositMoneyCommand {
+public class BankAccountMoneyDepositCommand {
 
     @TargetAggregateIdentifier
     private String bankAccountId;

--- a/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankAccountMoneyDepositedEvent.java
+++ b/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankAccountMoneyDepositedEvent.java
@@ -16,9 +16,9 @@
 
 package org.axonframework.samples.bank.api.bankaccount;
 
-public class MoneyDepositedEvent extends MoneyAddedEvent {
+public class BankAccountMoneyDepositedEvent extends BankAccountMoneyAddedEvent {
 
-    public MoneyDepositedEvent(String id, long amountOfMoneyDeposited) {
+    public BankAccountMoneyDepositedEvent(String id, long amountOfMoneyDeposited) {
         super(id, amountOfMoneyDeposited);
     }
 }

--- a/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankAccountMoneySubtractedEvent.java
+++ b/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankAccountMoneySubtractedEvent.java
@@ -17,12 +17,12 @@
 package org.axonframework.samples.bank.api.bankaccount;
 
 import lombok.Value;
-import org.axonframework.commandhandling.TargetAggregateIdentifier;
+import lombok.experimental.NonFinal;
 
 @Value
-public class ReturnMoneyOfFailedBankTransferCommand {
+@NonFinal
+public abstract class BankAccountMoneySubtractedEvent {
 
-    @TargetAggregateIdentifier
     private String bankAccountId;
     private long amount;
 }

--- a/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankAccountMoneyWithdrawnEvent.java
+++ b/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankAccountMoneyWithdrawnEvent.java
@@ -14,17 +14,11 @@
  * limitations under the License.
  */
 
-package org.axonframework.samples.bank.api.banktransfer;
+package org.axonframework.samples.bank.api.bankaccount;
 
-import lombok.Value;
-import org.axonframework.commandhandling.TargetAggregateIdentifier;
+public class BankAccountMoneyWithdrawnEvent extends BankAccountMoneySubtractedEvent {
 
-@Value
-public class CreateBankTransferCommand {
-
-    @TargetAggregateIdentifier
-    private String bankTransferId;
-    private String sourceBankAccountId;
-    private String destinationBankAccountId;
-    private long amount;
+    public BankAccountMoneyWithdrawnEvent(String bankAccountId, long amountOfMoney) {
+        super(bankAccountId, amountOfMoney);
+    }
 }

--- a/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankAccountWithdrawMoneyCommand.java
+++ b/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankAccountWithdrawMoneyCommand.java
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-package org.axonframework.samples.bank.api.banktransfer;
+package org.axonframework.samples.bank.api.bankaccount;
 
 import lombok.Value;
 import org.axonframework.commandhandling.TargetAggregateIdentifier;
 
 @Value
-public class MarkBankTransferFailedCommand {
+public class BankAccountWithdrawMoneyCommand {
 
     @TargetAggregateIdentifier
-    private String bankTransferId;
+    private String bankAccountId;
+    private long amountOfMoney;
 }

--- a/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankTransferDestinationCreditCommand.java
+++ b/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankTransferDestinationCreditCommand.java
@@ -17,12 +17,13 @@
 package org.axonframework.samples.bank.api.bankaccount;
 
 import lombok.Value;
-import lombok.experimental.NonFinal;
+import org.axonframework.commandhandling.TargetAggregateIdentifier;
 
 @Value
-@NonFinal
-public abstract class MoneySubtractedEvent {
+public class BankTransferDestinationCreditCommand {
 
+    @TargetAggregateIdentifier
     private String bankAccountId;
+    private String bankTransferId;
     private long amount;
 }

--- a/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankTransferDestinationCreditedEvent.java
+++ b/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankTransferDestinationCreditedEvent.java
@@ -19,12 +19,12 @@ package org.axonframework.samples.bank.api.bankaccount;
 import lombok.Getter;
 
 @Getter
-public class SourceBankAccountDebitedEvent extends MoneySubtractedEvent {
+public class BankTransferDestinationCreditedEvent extends BankAccountMoneyAddedEvent {
 
     private String bankTransferId;
 
-    public SourceBankAccountDebitedEvent(String id, long amountOfMoney, String bankTransferId) {
-        super(id, amountOfMoney);
+    public BankTransferDestinationCreditedEvent(String id, long amount, String bankTransferId) {
+        super(id, amount);
 
         this.bankTransferId = bankTransferId;
     }

--- a/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankTransferDestinationNotFoundEvent.java
+++ b/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankTransferDestinationNotFoundEvent.java
@@ -17,15 +17,9 @@
 package org.axonframework.samples.bank.api.bankaccount;
 
 import lombok.Value;
-import org.axonframework.commandhandling.TargetAggregateIdentifier;
-
-import javax.validation.constraints.Min;
 
 @Value
-public class CreateBankAccountCommand {
+public class BankTransferDestinationNotFoundEvent {
 
-    @TargetAggregateIdentifier
-    private String bankAccountId;
-    @Min(value = 0, message = "Overdraft limit must not be less than zero")
-    private long overdraftLimit;
+    private String bankTransferId;
 }

--- a/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankTransferSourceDebitCommand.java
+++ b/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankTransferSourceDebitCommand.java
@@ -20,7 +20,7 @@ import lombok.Value;
 import org.axonframework.commandhandling.TargetAggregateIdentifier;
 
 @Value
-public class DebitSourceBankAccountCommand {
+public class BankTransferSourceDebitCommand {
 
     @TargetAggregateIdentifier
     private String bankAccountId;

--- a/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankTransferSourceDebitRejectedEvent.java
+++ b/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankTransferSourceDebitRejectedEvent.java
@@ -16,9 +16,10 @@
 
 package org.axonframework.samples.bank.api.bankaccount;
 
-public class MoneyWithdrawnEvent extends MoneySubtractedEvent {
+import lombok.Value;
 
-    public MoneyWithdrawnEvent(String bankAccountId, long amountOfMoney) {
-        super(bankAccountId, amountOfMoney);
-    }
+@Value
+public class BankTransferSourceDebitRejectedEvent {
+
+    private String BankTransferId;
 }

--- a/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankTransferSourceDebitedEvent.java
+++ b/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankTransferSourceDebitedEvent.java
@@ -16,10 +16,16 @@
 
 package org.axonframework.samples.bank.api.bankaccount;
 
-import lombok.Value;
+import lombok.Getter;
 
-@Value
-public class SourceBankAccountDebitRejectedEvent {
+@Getter
+public class BankTransferSourceDebitedEvent extends BankAccountMoneySubtractedEvent {
 
-    private String BankTransferId;
+    private String bankTransferId;
+
+    public BankTransferSourceDebitedEvent(String id, long amountOfMoney, String bankTransferId) {
+        super(id, amountOfMoney);
+
+        this.bankTransferId = bankTransferId;
+    }
 }

--- a/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankTransferSourceNotFoundEvent.java
+++ b/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankTransferSourceNotFoundEvent.java
@@ -19,7 +19,7 @@ package org.axonframework.samples.bank.api.bankaccount;
 import lombok.Value;
 
 @Value
-public class SourceBankAccountNotFoundEvent {
+public class BankTransferSourceNotFoundEvent {
 
     private String bankTransferId;
 }

--- a/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankTransferSourceReturnMoneyCommand.java
+++ b/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankTransferSourceReturnMoneyCommand.java
@@ -20,10 +20,9 @@ import lombok.Value;
 import org.axonframework.commandhandling.TargetAggregateIdentifier;
 
 @Value
-public class CreditDestinationBankAccountCommand {
+public class BankTransferSourceReturnMoneyCommand {
 
     @TargetAggregateIdentifier
     private String bankAccountId;
-    private String bankTransferId;
     private long amount;
 }

--- a/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankTransferSourceReturnedMoneyOfFailedEvent.java
+++ b/core-api/src/main/java/org/axonframework/samples/bank/api/bankaccount/BankTransferSourceReturnedMoneyOfFailedEvent.java
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-package org.axonframework.samples.bank.api.banktransfer;
+package org.axonframework.samples.bank.api.bankaccount;
 
-import lombok.Value;
-import org.axonframework.commandhandling.TargetAggregateIdentifier;
+public class BankTransferSourceReturnedMoneyOfFailedEvent extends BankAccountMoneyAddedEvent {
 
-@Value
-public class MarkBankTransferCompletedCommand {
-
-    @TargetAggregateIdentifier
-    private String bankTransferId;
+    public BankTransferSourceReturnedMoneyOfFailedEvent(String bankAccountId, long amountOfMoneyDeposited) {
+        super(bankAccountId, amountOfMoneyDeposited);
+    }
 }

--- a/core-api/src/main/java/org/axonframework/samples/bank/api/banktransfer/BankTransferCreateCommand.java
+++ b/core-api/src/main/java/org/axonframework/samples/bank/api/banktransfer/BankTransferCreateCommand.java
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
-package org.axonframework.samples.bank.api.bankaccount;
+package org.axonframework.samples.bank.api.banktransfer;
 
 import lombok.Value;
-import lombok.experimental.NonFinal;
+import org.axonframework.commandhandling.TargetAggregateIdentifier;
 
 @Value
-@NonFinal
-public abstract class MoneyAddedEvent {
+public class BankTransferCreateCommand {
 
-    private String bankAccountId;
+    @TargetAggregateIdentifier
+    private String bankTransferId;
+    private String sourceBankAccountId;
+    private String destinationBankAccountId;
     private long amount;
 }

--- a/core-api/src/main/java/org/axonframework/samples/bank/api/banktransfer/BankTransferMarkCompletedCommand.java
+++ b/core-api/src/main/java/org/axonframework/samples/bank/api/banktransfer/BankTransferMarkCompletedCommand.java
@@ -14,18 +14,14 @@
  * limitations under the License.
  */
 
-package org.axonframework.samples.bank.api.bankaccount;
+package org.axonframework.samples.bank.api.banktransfer;
 
-import lombok.Getter;
+import lombok.Value;
+import org.axonframework.commandhandling.TargetAggregateIdentifier;
 
-@Getter
-public class DestinationBankAccountCreditedEvent extends MoneyAddedEvent {
+@Value
+public class BankTransferMarkCompletedCommand {
 
+    @TargetAggregateIdentifier
     private String bankTransferId;
-
-    public DestinationBankAccountCreditedEvent(String id, long amount, String bankTransferId) {
-        super(id, amount);
-
-        this.bankTransferId = bankTransferId;
-    }
 }

--- a/core-api/src/main/java/org/axonframework/samples/bank/api/banktransfer/BankTransferMarkFailedCommand.java
+++ b/core-api/src/main/java/org/axonframework/samples/bank/api/banktransfer/BankTransferMarkFailedCommand.java
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-package org.axonframework.samples.bank.api.bankaccount;
+package org.axonframework.samples.bank.api.banktransfer;
 
 import lombok.Value;
+import org.axonframework.commandhandling.TargetAggregateIdentifier;
 
 @Value
-public class DestinationBankAccountNotFoundEvent {
+public class BankTransferMarkFailedCommand {
 
+    @TargetAggregateIdentifier
     private String bankTransferId;
 }

--- a/core/src/main/java/org/axonframework/samples/bank/command/BankAccount.java
+++ b/core/src/main/java/org/axonframework/samples/bank/command/BankAccount.java
@@ -19,14 +19,14 @@ package org.axonframework.samples.bank.command;
 import org.axonframework.commandhandling.model.AggregateIdentifier;
 import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.samples.bank.api.bankaccount.BankAccountCreatedEvent;
-import org.axonframework.samples.bank.api.bankaccount.DestinationBankAccountCreditedEvent;
-import org.axonframework.samples.bank.api.bankaccount.MoneyAddedEvent;
-import org.axonframework.samples.bank.api.bankaccount.MoneyDepositedEvent;
-import org.axonframework.samples.bank.api.bankaccount.MoneyOfFailedBankTransferReturnedEvent;
-import org.axonframework.samples.bank.api.bankaccount.MoneySubtractedEvent;
-import org.axonframework.samples.bank.api.bankaccount.MoneyWithdrawnEvent;
-import org.axonframework.samples.bank.api.bankaccount.SourceBankAccountDebitRejectedEvent;
-import org.axonframework.samples.bank.api.bankaccount.SourceBankAccountDebitedEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferDestinationCreditedEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankAccountMoneyAddedEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankAccountMoneyDepositedEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferSourceReturnedMoneyOfFailedEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankAccountMoneySubtractedEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankAccountMoneyWithdrawnEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferSourceDebitRejectedEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferSourceDebitedEvent;
 import org.axonframework.spring.stereotype.Aggregate;
 
 import static org.axonframework.commandhandling.model.AggregateLifecycle.apply;
@@ -48,30 +48,30 @@ public class BankAccount {
     }
 
     public void deposit(long amount) {
-        apply(new MoneyDepositedEvent(id, amount));
+        apply(new BankAccountMoneyDepositedEvent(id, amount));
     }
 
     public void withdraw(long amount) {
         if (amount <= balanceInCents + overdraftLimit) {
-            apply(new MoneyWithdrawnEvent(id, amount));
+            apply(new BankAccountMoneyWithdrawnEvent(id, amount));
         }
     }
 
     public void debit(long amount, String bankTransferId) {
         if (amount <= balanceInCents + overdraftLimit) {
-            apply(new SourceBankAccountDebitedEvent(id, amount, bankTransferId));
+            apply(new BankTransferSourceDebitedEvent(id, amount, bankTransferId));
         }
         else {
-            apply(new SourceBankAccountDebitRejectedEvent(bankTransferId));
+            apply(new BankTransferSourceDebitRejectedEvent(bankTransferId));
         }
     }
 
     public void credit(long amount, String bankTransferId) {
-        apply(new DestinationBankAccountCreditedEvent(id, amount, bankTransferId));
+        apply(new BankTransferDestinationCreditedEvent(id, amount, bankTransferId));
     }
 
     public void returnMoney(long amount) {
-        apply(new MoneyOfFailedBankTransferReturnedEvent(id, amount));
+        apply(new BankTransferSourceReturnedMoneyOfFailedEvent(id, amount));
     }
 
     @EventHandler
@@ -82,12 +82,12 @@ public class BankAccount {
     }
 
     @EventHandler
-    public void on(MoneyAddedEvent event) {
+    public void on(BankAccountMoneyAddedEvent event) {
         balanceInCents += event.getAmount();
     }
 
     @EventHandler
-    public void on(MoneySubtractedEvent event) {
+    public void on(BankAccountMoneySubtractedEvent event) {
         balanceInCents -= event.getAmount();
     }
 }

--- a/core/src/main/java/org/axonframework/samples/bank/command/BankTransfer.java
+++ b/core/src/main/java/org/axonframework/samples/bank/command/BankTransfer.java
@@ -22,9 +22,9 @@ import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.samples.bank.api.banktransfer.BankTransferCompletedEvent;
 import org.axonframework.samples.bank.api.banktransfer.BankTransferCreatedEvent;
 import org.axonframework.samples.bank.api.banktransfer.BankTransferFailedEvent;
-import org.axonframework.samples.bank.api.banktransfer.CreateBankTransferCommand;
-import org.axonframework.samples.bank.api.banktransfer.MarkBankTransferCompletedCommand;
-import org.axonframework.samples.bank.api.banktransfer.MarkBankTransferFailedCommand;
+import org.axonframework.samples.bank.api.banktransfer.BankTransferCreateCommand;
+import org.axonframework.samples.bank.api.banktransfer.BankTransferMarkCompletedCommand;
+import org.axonframework.samples.bank.api.banktransfer.BankTransferMarkFailedCommand;
 import org.axonframework.spring.stereotype.Aggregate;
 
 import static org.axonframework.commandhandling.model.AggregateLifecycle.apply;
@@ -44,7 +44,7 @@ public class BankTransfer {
     }
 
     @CommandHandler
-    public BankTransfer(CreateBankTransferCommand command) {
+    public BankTransfer(BankTransferCreateCommand command) {
         apply(new BankTransferCreatedEvent(command.getBankTransferId(),
                                            command.getSourceBankAccountId(),
                                            command.getDestinationBankAccountId(),
@@ -52,12 +52,12 @@ public class BankTransfer {
     }
 
     @CommandHandler
-    public void handle(MarkBankTransferCompletedCommand command) {
+    public void handle(BankTransferMarkCompletedCommand command) {
         apply(new BankTransferCompletedEvent(command.getBankTransferId()));
     }
 
     @CommandHandler
-    public void handle(MarkBankTransferFailedCommand command) {
+    public void handle(BankTransferMarkFailedCommand command) {
         apply(new BankTransferFailedEvent(command.getBankTransferId()));
     }
 

--- a/core/src/main/java/org/axonframework/samples/bank/command/BankTransferManagementSaga.java
+++ b/core/src/main/java/org/axonframework/samples/bank/command/BankTransferManagementSaga.java
@@ -20,17 +20,17 @@ import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.eventhandling.saga.EndSaga;
 import org.axonframework.eventhandling.saga.SagaEventHandler;
 import org.axonframework.eventhandling.saga.StartSaga;
-import org.axonframework.samples.bank.api.bankaccount.CreditDestinationBankAccountCommand;
-import org.axonframework.samples.bank.api.bankaccount.DebitSourceBankAccountCommand;
-import org.axonframework.samples.bank.api.bankaccount.DestinationBankAccountCreditedEvent;
-import org.axonframework.samples.bank.api.bankaccount.DestinationBankAccountNotFoundEvent;
-import org.axonframework.samples.bank.api.bankaccount.ReturnMoneyOfFailedBankTransferCommand;
-import org.axonframework.samples.bank.api.bankaccount.SourceBankAccountDebitRejectedEvent;
-import org.axonframework.samples.bank.api.bankaccount.SourceBankAccountDebitedEvent;
-import org.axonframework.samples.bank.api.bankaccount.SourceBankAccountNotFoundEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferDestinationCreditCommand;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferSourceDebitCommand;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferDestinationCreditedEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferDestinationNotFoundEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferSourceReturnMoneyCommand;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferSourceDebitRejectedEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferSourceDebitedEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferSourceNotFoundEvent;
 import org.axonframework.samples.bank.api.banktransfer.BankTransferCreatedEvent;
-import org.axonframework.samples.bank.api.banktransfer.MarkBankTransferCompletedCommand;
-import org.axonframework.samples.bank.api.banktransfer.MarkBankTransferFailedCommand;
+import org.axonframework.samples.bank.api.banktransfer.BankTransferMarkCompletedCommand;
+import org.axonframework.samples.bank.api.banktransfer.BankTransferMarkFailedCommand;
 import org.axonframework.spring.stereotype.Saga;
 
 import javax.inject.Inject;
@@ -58,7 +58,7 @@ public class BankTransferManagementSaga {
         this.destinationBankAccountId = event.getDestinationBankAccountId();
         this.amount = event.getAmount();
 
-        DebitSourceBankAccountCommand command = new DebitSourceBankAccountCommand(event.getSourceBankAccountId(),
+        BankTransferSourceDebitCommand command = new BankTransferSourceDebitCommand(event.getSourceBankAccountId(),
                                                                                   event.getBankTransferId(),
                                                                                   event.getAmount());
         commandBus.dispatch(asCommandMessage(command));
@@ -66,21 +66,21 @@ public class BankTransferManagementSaga {
 
     @SagaEventHandler(associationProperty = "bankTransferId")
     @EndSaga
-    public void on(SourceBankAccountNotFoundEvent event) {
-        MarkBankTransferFailedCommand markFailedCommand = new MarkBankTransferFailedCommand(event.getBankTransferId());
+    public void on(BankTransferSourceNotFoundEvent event) {
+        BankTransferMarkFailedCommand markFailedCommand = new BankTransferMarkFailedCommand(event.getBankTransferId());
         commandBus.dispatch(asCommandMessage(markFailedCommand));
     }
 
     @SagaEventHandler(associationProperty = "bankTransferId")
     @EndSaga
-    public void on(SourceBankAccountDebitRejectedEvent event) {
-        MarkBankTransferFailedCommand markFailedCommand = new MarkBankTransferFailedCommand(event.getBankTransferId());
+    public void on(BankTransferSourceDebitRejectedEvent event) {
+        BankTransferMarkFailedCommand markFailedCommand = new BankTransferMarkFailedCommand(event.getBankTransferId());
         commandBus.dispatch(asCommandMessage(markFailedCommand));
     }
 
     @SagaEventHandler(associationProperty = "bankTransferId")
-    public void on(SourceBankAccountDebitedEvent event) {
-        CreditDestinationBankAccountCommand command = new CreditDestinationBankAccountCommand(destinationBankAccountId,
+    public void on(BankTransferSourceDebitedEvent event) {
+        BankTransferDestinationCreditCommand command = new BankTransferDestinationCreditCommand(destinationBankAccountId,
                                                                                               event.getBankTransferId(),
                                                                                               event.getAmount());
         commandBus.dispatch(asCommandMessage(command));
@@ -88,21 +88,21 @@ public class BankTransferManagementSaga {
 
     @SagaEventHandler(associationProperty = "bankTransferId")
     @EndSaga
-    public void on(DestinationBankAccountNotFoundEvent event) {
-        ReturnMoneyOfFailedBankTransferCommand returnMoneyCommand = new ReturnMoneyOfFailedBankTransferCommand(
+    public void on(BankTransferDestinationNotFoundEvent event) {
+        BankTransferSourceReturnMoneyCommand returnMoneyCommand = new BankTransferSourceReturnMoneyCommand(
                 sourceBankAccountId,
                 amount);
         commandBus.dispatch(asCommandMessage(returnMoneyCommand));
 
-        MarkBankTransferFailedCommand markFailedCommand = new MarkBankTransferFailedCommand(
+        BankTransferMarkFailedCommand markFailedCommand = new BankTransferMarkFailedCommand(
                 event.getBankTransferId());
         commandBus.dispatch(asCommandMessage(markFailedCommand));
     }
 
     @EndSaga
     @SagaEventHandler(associationProperty = "bankTransferId")
-    public void on(DestinationBankAccountCreditedEvent event) {
-        MarkBankTransferCompletedCommand command = new MarkBankTransferCompletedCommand(event.getBankTransferId());
+    public void on(BankTransferDestinationCreditedEvent event) {
+        BankTransferMarkCompletedCommand command = new BankTransferMarkCompletedCommand(event.getBankTransferId());
         commandBus.dispatch(asCommandMessage(command));
     }
 }

--- a/core/src/test/java/org/axonframework/samples/bank/command/BankAccountCommandHandlerTest.java
+++ b/core/src/test/java/org/axonframework/samples/bank/command/BankAccountCommandHandlerTest.java
@@ -19,11 +19,11 @@ package org.axonframework.samples.bank.command;
 import org.axonframework.messaging.interceptors.BeanValidationInterceptor;
 import org.axonframework.messaging.interceptors.JSR303ViolationException;
 import org.axonframework.samples.bank.api.bankaccount.BankAccountCreatedEvent;
-import org.axonframework.samples.bank.api.bankaccount.CreateBankAccountCommand;
-import org.axonframework.samples.bank.api.bankaccount.DepositMoneyCommand;
-import org.axonframework.samples.bank.api.bankaccount.MoneyDepositedEvent;
-import org.axonframework.samples.bank.api.bankaccount.MoneyWithdrawnEvent;
-import org.axonframework.samples.bank.api.bankaccount.WithdrawMoneyCommand;
+import org.axonframework.samples.bank.api.bankaccount.BankAccountCreateCommand;
+import org.axonframework.samples.bank.api.bankaccount.BankAccountMoneyDepositCommand;
+import org.axonframework.samples.bank.api.bankaccount.BankAccountMoneyDepositedEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankAccountMoneyWithdrawnEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankAccountWithdrawMoneyCommand;
 import org.axonframework.test.aggregate.AggregateTestFixture;
 import org.axonframework.test.aggregate.FixtureConfiguration;
 import org.junit.*;
@@ -46,7 +46,7 @@ public class BankAccountCommandHandlerTest {
     @Test(expected = JSR303ViolationException.class)
     public void testCreateBankAccount_RejectNegativeOverdraft() throws Exception {
         testFixture.givenNoPriorActivity()
-                   .when(new CreateBankAccountCommand(UUID.randomUUID().toString(), -1000));
+                   .when(new BankAccountCreateCommand(UUID.randomUUID().toString(), -1000));
     }
 
     @Test
@@ -54,7 +54,7 @@ public class BankAccountCommandHandlerTest {
         String id = "bankAccountId";
 
         testFixture.givenNoPriorActivity()
-                   .when(new CreateBankAccountCommand(id, 0))
+                   .when(new BankAccountCreateCommand(id, 0))
                    .expectEvents(new BankAccountCreatedEvent(id, 0));
     }
 
@@ -63,25 +63,25 @@ public class BankAccountCommandHandlerTest {
         String id = "bankAccountId";
 
         testFixture.given(new BankAccountCreatedEvent(id, 0))
-                   .when(new DepositMoneyCommand(id, 1000))
-                   .expectEvents(new MoneyDepositedEvent(id, 1000));
+                   .when(new BankAccountMoneyDepositCommand(id, 1000))
+                   .expectEvents(new BankAccountMoneyDepositedEvent(id, 1000));
     }
 
     @Test
     public void testWithdrawMoney() throws Exception {
         String id = "bankAccountId";
 
-        testFixture.given(new BankAccountCreatedEvent(id, 0), new MoneyDepositedEvent(id, 50))
-                   .when(new WithdrawMoneyCommand(id, 50))
-                   .expectEvents(new MoneyWithdrawnEvent(id, 50));
+        testFixture.given(new BankAccountCreatedEvent(id, 0), new BankAccountMoneyDepositedEvent(id, 50))
+                   .when(new BankAccountWithdrawMoneyCommand(id, 50))
+                   .expectEvents(new BankAccountMoneyWithdrawnEvent(id, 50));
     }
 
     @Test
     public void testWithdrawMoney_RejectWithdrawal() throws Exception {
         String id = "bankAccountId";
 
-        testFixture.given(new BankAccountCreatedEvent(id, 0), new MoneyDepositedEvent(id, 50))
-                   .when(new WithdrawMoneyCommand(id, 51))
+        testFixture.given(new BankAccountCreatedEvent(id, 0), new BankAccountMoneyDepositedEvent(id, 50))
+                   .when(new BankAccountWithdrawMoneyCommand(id, 51))
                    .expectEvents();
     }
 }

--- a/core/src/test/java/org/axonframework/samples/bank/command/BankTransferManagementSagaTest.java
+++ b/core/src/test/java/org/axonframework/samples/bank/command/BankTransferManagementSagaTest.java
@@ -1,16 +1,16 @@
 package org.axonframework.samples.bank.command;
 
-import org.axonframework.samples.bank.api.bankaccount.CreditDestinationBankAccountCommand;
-import org.axonframework.samples.bank.api.bankaccount.DebitSourceBankAccountCommand;
-import org.axonframework.samples.bank.api.bankaccount.DestinationBankAccountCreditedEvent;
-import org.axonframework.samples.bank.api.bankaccount.DestinationBankAccountNotFoundEvent;
-import org.axonframework.samples.bank.api.bankaccount.ReturnMoneyOfFailedBankTransferCommand;
-import org.axonframework.samples.bank.api.bankaccount.SourceBankAccountDebitRejectedEvent;
-import org.axonframework.samples.bank.api.bankaccount.SourceBankAccountDebitedEvent;
-import org.axonframework.samples.bank.api.bankaccount.SourceBankAccountNotFoundEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferDestinationCreditCommand;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferSourceDebitCommand;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferDestinationCreditedEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferDestinationNotFoundEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferSourceReturnMoneyCommand;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferSourceDebitRejectedEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferSourceDebitedEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankTransferSourceNotFoundEvent;
 import org.axonframework.samples.bank.api.banktransfer.BankTransferCreatedEvent;
-import org.axonframework.samples.bank.api.banktransfer.MarkBankTransferCompletedCommand;
-import org.axonframework.samples.bank.api.banktransfer.MarkBankTransferFailedCommand;
+import org.axonframework.samples.bank.api.banktransfer.BankTransferMarkCompletedCommand;
+import org.axonframework.samples.bank.api.banktransfer.BankTransferMarkFailedCommand;
 import org.axonframework.test.saga.FixtureConfiguration;
 import org.axonframework.test.saga.SagaTestFixture;
 import org.junit.*;
@@ -37,7 +37,7 @@ public class BankTransferManagementSagaTest {
                                                                                          destinationBankAccountId,
                                                                                          amountOfMoneyToTransfer))
                    .expectActiveSagas(1)
-                   .expectDispatchedCommands(new DebitSourceBankAccountCommand(sourceBankAccountId,
+                   .expectDispatchedCommands(new BankTransferSourceDebitCommand(sourceBankAccountId,
                                                                                bankTransferId,
                                                                                amountOfMoneyToTransfer));
     }
@@ -53,9 +53,9 @@ public class BankTransferManagementSagaTest {
                                                                                           sourceBankAccountId,
                                                                                           destinationBankAccountId,
                                                                                           amountOfMoneyToTransfer))
-                   .whenPublishingA(new SourceBankAccountNotFoundEvent(bankTransferId))
+                   .whenPublishingA(new BankTransferSourceNotFoundEvent(bankTransferId))
                    .expectActiveSagas(0)
-                   .expectDispatchedCommands(new MarkBankTransferFailedCommand(bankTransferId));
+                   .expectDispatchedCommands(new BankTransferMarkFailedCommand(bankTransferId));
     }
 
     @Test
@@ -70,9 +70,9 @@ public class BankTransferManagementSagaTest {
                                                                                           destinationBankAccountId,
                                                                                           amountOfMoneyToTransfer))
                    .whenAggregate(sourceBankAccountId)
-                   .publishes(new SourceBankAccountDebitRejectedEvent(bankTransferId))
+                   .publishes(new BankTransferSourceDebitRejectedEvent(bankTransferId))
                    .expectActiveSagas(0)
-                   .expectDispatchedCommands(new MarkBankTransferFailedCommand(bankTransferId));
+                   .expectDispatchedCommands(new BankTransferMarkFailedCommand(bankTransferId));
     }
 
     @Test
@@ -86,11 +86,11 @@ public class BankTransferManagementSagaTest {
                                                                                           sourceBankAccountId,
                                                                                           destinationBankAccountId,
                                                                                           amountOfMoneyToTransfer))
-                   .whenAggregate(sourceBankAccountId).publishes(new SourceBankAccountDebitedEvent(sourceBankAccountId,
+                   .whenAggregate(sourceBankAccountId).publishes(new BankTransferSourceDebitedEvent(sourceBankAccountId,
                                                                                                    amountOfMoneyToTransfer,
                                                                                                    bankTransferId))
                    .expectActiveSagas(1)
-                   .expectDispatchedCommands(new CreditDestinationBankAccountCommand(destinationBankAccountId,
+                   .expectDispatchedCommands(new BankTransferDestinationCreditCommand(destinationBankAccountId,
                                                                                      bankTransferId,
                                                                                      amountOfMoneyToTransfer));
     }
@@ -106,13 +106,13 @@ public class BankTransferManagementSagaTest {
                                                                                           sourceBankAccountId,
                                                                                           destinationBankAccountId,
                                                                                           amountOfMoneyToTransfer))
-                   .andThenAggregate(sourceBankAccountId).published(new SourceBankAccountDebitedEvent(
+                   .andThenAggregate(sourceBankAccountId).published(new BankTransferSourceDebitedEvent(
                 sourceBankAccountId, amountOfMoneyToTransfer, bankTransferId))
-                   .whenPublishingA(new DestinationBankAccountNotFoundEvent(bankTransferId))
+                   .whenPublishingA(new BankTransferDestinationNotFoundEvent(bankTransferId))
                    .expectActiveSagas(0)
-                   .expectDispatchedCommands(new ReturnMoneyOfFailedBankTransferCommand(sourceBankAccountId,
+                   .expectDispatchedCommands(new BankTransferSourceReturnMoneyCommand(sourceBankAccountId,
                                                                                         amountOfMoneyToTransfer),
-                                             new MarkBankTransferFailedCommand(bankTransferId));
+                                             new BankTransferMarkFailedCommand(bankTransferId));
     }
 
     @Test
@@ -126,15 +126,15 @@ public class BankTransferManagementSagaTest {
                                                                                           sourceBankAccountId,
                                                                                           destinationBankAccountId,
                                                                                           amountOfMoneyToTransfer))
-                   .andThenAggregate(sourceBankAccountId).published(new SourceBankAccountDebitedEvent(
+                   .andThenAggregate(sourceBankAccountId).published(new BankTransferSourceDebitedEvent(
                 sourceBankAccountId,
                 amountOfMoneyToTransfer,
                 bankTransferId))
-                   .whenAggregate(destinationBankAccountId).publishes(new DestinationBankAccountCreditedEvent(
+                   .whenAggregate(destinationBankAccountId).publishes(new BankTransferDestinationCreditedEvent(
                 destinationBankAccountId,
                 amountOfMoneyToTransfer,
                 bankTransferId))
                    .expectActiveSagas(0)
-                   .expectDispatchedCommands(new MarkBankTransferCompletedCommand(bankTransferId));
+                   .expectDispatchedCommands(new BankTransferMarkCompletedCommand(bankTransferId));
     }
 }

--- a/core/src/test/java/org/axonframework/samples/bank/command/BankTransferTest.java
+++ b/core/src/test/java/org/axonframework/samples/bank/command/BankTransferTest.java
@@ -19,9 +19,9 @@ package org.axonframework.samples.bank.command;
 import org.axonframework.samples.bank.api.banktransfer.BankTransferCompletedEvent;
 import org.axonframework.samples.bank.api.banktransfer.BankTransferCreatedEvent;
 import org.axonframework.samples.bank.api.banktransfer.BankTransferFailedEvent;
-import org.axonframework.samples.bank.api.banktransfer.CreateBankTransferCommand;
-import org.axonframework.samples.bank.api.banktransfer.MarkBankTransferCompletedCommand;
-import org.axonframework.samples.bank.api.banktransfer.MarkBankTransferFailedCommand;
+import org.axonframework.samples.bank.api.banktransfer.BankTransferCreateCommand;
+import org.axonframework.samples.bank.api.banktransfer.BankTransferMarkCompletedCommand;
+import org.axonframework.samples.bank.api.banktransfer.BankTransferMarkFailedCommand;
 import org.axonframework.test.aggregate.AggregateTestFixture;
 import org.axonframework.test.aggregate.FixtureConfiguration;
 import org.junit.*;
@@ -42,7 +42,7 @@ public class BankTransferTest {
         String destinationBankAccountId = "destinationBankAccountId";
 
         fixture.givenNoPriorActivity()
-               .when(new CreateBankTransferCommand(bankTransferId, sourceBankAccountId, destinationBankAccountId, 20))
+               .when(new BankTransferCreateCommand(bankTransferId, sourceBankAccountId, destinationBankAccountId, 20))
                .expectEvents(new BankTransferCreatedEvent(bankTransferId,
                                                           sourceBankAccountId,
                                                           destinationBankAccountId,
@@ -56,7 +56,7 @@ public class BankTransferTest {
         String destinationBankAccountId = "destinationBankAccountId";
 
         fixture.given(new BankTransferCreatedEvent(bankTransferId, sourceBankAccountId, destinationBankAccountId, 20))
-               .when(new MarkBankTransferCompletedCommand(bankTransferId))
+               .when(new BankTransferMarkCompletedCommand(bankTransferId))
                .expectEvents(new BankTransferCompletedEvent(bankTransferId));
     }
 
@@ -67,7 +67,7 @@ public class BankTransferTest {
         String destinationBankAccountId = "destinationBankAccountId";
 
         fixture.given(new BankTransferCreatedEvent(bankTransferId, sourceBankAccountId, destinationBankAccountId, 20))
-               .when(new MarkBankTransferFailedCommand(bankTransferId))
+               .when(new BankTransferMarkFailedCommand(bankTransferId))
                .expectEvents(new BankTransferFailedEvent(bankTransferId));
     }
 }

--- a/query/src/main/java/org/axonframework/samples/bank/query/bankaccount/BankAccountEventListener.java
+++ b/query/src/main/java/org/axonframework/samples/bank/query/bankaccount/BankAccountEventListener.java
@@ -18,8 +18,8 @@ package org.axonframework.samples.bank.query.bankaccount;
 
 import org.axonframework.eventhandling.EventHandler;
 import org.axonframework.samples.bank.api.bankaccount.BankAccountCreatedEvent;
-import org.axonframework.samples.bank.api.bankaccount.MoneyAddedEvent;
-import org.axonframework.samples.bank.api.bankaccount.MoneySubtractedEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankAccountMoneyAddedEvent;
+import org.axonframework.samples.bank.api.bankaccount.BankAccountMoneySubtractedEvent;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Component;
@@ -44,7 +44,7 @@ public class BankAccountEventListener {
     }
 
     @EventHandler
-    public void on(MoneyAddedEvent event) {
+    public void on(BankAccountMoneyAddedEvent event) {
         BankAccountEntry bankAccountEntry = repository.findOneByAxonBankAccountId(event.getBankAccountId());
         bankAccountEntry.setBalance(bankAccountEntry.getBalance() + event.getAmount());
 
@@ -54,7 +54,7 @@ public class BankAccountEventListener {
     }
 
     @EventHandler
-    public void on(MoneySubtractedEvent event) {
+    public void on(BankAccountMoneySubtractedEvent event) {
         BankAccountEntry bankAccountEntry = repository.findOneByAxonBankAccountId(event.getBankAccountId());
         bankAccountEntry.setBalance(bankAccountEntry.getBalance() - event.getAmount());
 

--- a/web/src/main/java/org/axonframework/samples/bank/web/BankAccountController.java
+++ b/web/src/main/java/org/axonframework/samples/bank/web/BankAccountController.java
@@ -18,9 +18,9 @@ package org.axonframework.samples.bank.web;
 
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.GenericCommandMessage;
-import org.axonframework.samples.bank.api.bankaccount.CreateBankAccountCommand;
-import org.axonframework.samples.bank.api.bankaccount.DepositMoneyCommand;
-import org.axonframework.samples.bank.api.bankaccount.WithdrawMoneyCommand;
+import org.axonframework.samples.bank.api.bankaccount.BankAccountCreateCommand;
+import org.axonframework.samples.bank.api.bankaccount.BankAccountMoneyDepositCommand;
+import org.axonframework.samples.bank.api.bankaccount.BankAccountWithdrawMoneyCommand;
 import org.axonframework.samples.bank.query.bankaccount.BankAccountEntry;
 import org.axonframework.samples.bank.query.bankaccount.BankAccountRepository;
 import org.axonframework.samples.bank.web.dto.BankAccountDto;
@@ -61,19 +61,19 @@ public class BankAccountController {
     @MessageMapping("/create")
     public void create(BankAccountDto bankAccountDto) {
         String id = UUID.randomUUID().toString();
-        CreateBankAccountCommand command = new CreateBankAccountCommand(id, bankAccountDto.getOverdraftLimit());
+        BankAccountCreateCommand command = new BankAccountCreateCommand(id, bankAccountDto.getOverdraftLimit());
         commandBus.dispatch(GenericCommandMessage.asCommandMessage(command));
     }
 
     @MessageMapping("/withdraw")
     public void withdraw(WithdrawalDto depositDto) {
-        WithdrawMoneyCommand command = new WithdrawMoneyCommand(depositDto.getBankAccountId(), depositDto.getAmount());
+        BankAccountWithdrawMoneyCommand command = new BankAccountWithdrawMoneyCommand(depositDto.getBankAccountId(), depositDto.getAmount());
         commandBus.dispatch(GenericCommandMessage.asCommandMessage(command));
     }
 
     @MessageMapping("/deposit")
     public void deposit(DepositDto depositDto) {
-        DepositMoneyCommand command = new DepositMoneyCommand(depositDto.getBankAccountId(), depositDto.getAmount());
+        BankAccountMoneyDepositCommand command = new BankAccountMoneyDepositCommand(depositDto.getBankAccountId(), depositDto.getAmount());
         commandBus.dispatch(GenericCommandMessage.asCommandMessage(command));
     }
 }

--- a/web/src/main/java/org/axonframework/samples/bank/web/BankTransferController.java
+++ b/web/src/main/java/org/axonframework/samples/bank/web/BankTransferController.java
@@ -18,7 +18,7 @@ package org.axonframework.samples.bank.web;
 
 import org.axonframework.commandhandling.CommandBus;
 import org.axonframework.commandhandling.GenericCommandMessage;
-import org.axonframework.samples.bank.api.banktransfer.CreateBankTransferCommand;
+import org.axonframework.samples.bank.api.banktransfer.BankTransferCreateCommand;
 import org.axonframework.samples.bank.query.banktransfer.BankTransferEntry;
 import org.axonframework.samples.bank.query.banktransfer.BankTransferRepository;
 import org.axonframework.samples.bank.web.dto.BankTransferDto;
@@ -58,7 +58,7 @@ public class BankTransferController {
     @MessageMapping("/bank-transfers/create")
     public void create(BankTransferDto bankTransferDto) {
         String bankTransferId = UUID.randomUUID().toString();
-        CreateBankTransferCommand command = new CreateBankTransferCommand(bankTransferId,
+        BankTransferCreateCommand command = new BankTransferCreateCommand(bankTransferId,
                                                                           bankTransferDto.getSourceBankAccountId(),
                                                                           bankTransferDto.getDestinationBankAccountId(),
                                                                           bankTransferDto.getAmount());


### PR DESCRIPTION
rename Command name and event name since that is difficult to understand

CreateBankAccountCommand	→	BankAccountCreateCommand
MoneyAddedEvent	→	BankAccountMoneyAddedEvent
DepositMoneyCommand	→	BankAccountMoneyDepositCommand
MoneyDepositedEvent	→	BankAccountMoneyDepositedEvent
MoneySubtractedEvent	→	BankAccountMoneySubtractedEvent
MoneyWithdrawnEvent	→	BankAccountMoneyWithdrawnEvent
WithdrawMoneyCommand	→	BankAccountWithdrawMoneyCommand
CreateBankTransferCommand	→	BankTransferCreateCommand
BankTransferCreatedEvent	→	BankTransferCreatedEvent
CreditDestinationBankAccountCommand	→	BankTransferDestinationCreditCommand
DestinationBankAccountCreditedEvent	→	BankTransferDestinationCreditedEvent
DestinationBankAccountNotFoundEvent	→	BankTransferDestinationNotFoundEvent
MarkBankTransferCompletedCommand	→	BankTransferMarkCompletedCommand
MarkBankTransferFailedCommand	→	BankTransferMarkFailedCommand
DebitSourceBankAccountCommand	→	BankTransferSourceDebitCommand
SourceBankAccountDebitedEvent	→	BankTransferSourceDebitedEvent
SourceBankAccountDebitRejectedEvent	→	BankTransferSourceDebitRejectedEvent
SourceBankAccountNotFoundEvent	→	BankTransferSourceNotFoundEvent
MoneyOfFailedBankTransferReturnedEvent	→	BankTransferSourceReturnedMoneyOfFailedEvent
ReturnMoneyOfFailedBankTransferCommand	→	BankTransferSourceReturnMoneyCommand
