### PR TITLE
use h2 when running in single node mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The distributed version requires Docker and Docker Compose to be installed. Ther
 ## Usage
 In order to run the single node version you may execute the following commands: 
 * `mvn clean install`
-* `mvn -pl web spring-boot:run`.
+* `java -jar web/target/axon-bank-web-0.0.1-SNAPSHOT.jar`.
 
 The distributed version can be run using the following commands:
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,10 @@
             <artifactId>spring-boot-devtools</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
         </dependency>

--- a/web/src/main/resources/application-distributed.properties
+++ b/web/src/main/resources/application-distributed.properties
@@ -15,3 +15,12 @@
 #
 axon.distributed.enabled=true
 eureka.instance.hostname=localhost
+
+spring.datasource.url=jdbc:mysql://db:3306/axonbank
+spring.datasource.username=root
+spring.datasource.password=root
+
+spring.jpa.generate-ddl=true
+spring.jpa.hibernate.ddl-auto=update
+
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5Dialect

--- a/web/src/main/resources/application.properties
+++ b/web/src/main/resources/application.properties
@@ -1,10 +1,3 @@
 spring.application.name=Axon Bank
 
-spring.datasource.url=jdbc:mysql://db:3306/axonbank
-spring.datasource.username=root
-spring.datasource.password=root
-
-spring.jpa.generate-ddl=true
-spring.jpa.hibernate.ddl-auto=update
-
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5Dialect
+spring.h2.console.enabled=true


### PR DESCRIPTION
When running in single node mode would be more convenient to use `h2` instead of mysql. The user could peak into the internal tables with `http://localhost:8080/h2-console` endpoint.